### PR TITLE
feat(ci): auto-archive stable releases to Zenodo (deposit API)

### DIFF
--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -1,0 +1,44 @@
+name: Archive stable release to Zenodo
+
+# Quando pubblichi una Release STABILE (non prerelease), archivia il sorgente del
+# tag come NUOVA VERSIONE su Zenodo, via API deposizioni. Sostituisce il webhook
+# GitHub->Zenodo (disattivato perche' dopo la migrazione a InvenioRDM falliva con
+# errore vuoto {"errors": ""}). Idempotente e non bloccante.
+#
+# Richiede il secret di repo ZENODO_TOKEN (scope deposit:write + deposit:actions).
+# Se il secret manca, lo script salta senza errore.
+#
+# Gira dal branch di DEFAULT (main) per l'evento `release`, qualunque sia il
+# branch da cui e' stato tagliato il tag.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  zenodo:
+    # solo release stabili (le prerelease non vanno archiviate)
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build source archive of the released tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # usa il .zenodo.json del tag se presente (metadati di quella versione);
+          # altrimenti resta quello del branch di default come fallback.
+          git show "refs/tags/${TAG}:.zenodo.json" > .zenodo.json 2>/dev/null || true
+          git archive --format=zip --prefix="ExtendedMatrix-${TAG}/" "refs/tags/${TAG}" \
+            -o "ExtendedMatrix-${TAG}.zip"
+          ls -la "ExtendedMatrix-${TAG}.zip" .zenodo.json
+
+      - name: Publish source to Zenodo
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          ZENODO_CONCEPT: "5957132"
+          TAG: ${{ github.event.release.tag_name }}
+          SRC_ZIP: "ExtendedMatrix-${{ github.event.release.tag_name }}.zip"
+        run: python3 scripts/zenodo_publish.py

--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -1,44 +1,49 @@
-name: Archive stable release to Zenodo
+name: Archive release to Zenodo
 
-# Quando pubblichi una Release STABILE (non prerelease), archivia il sorgente del
-# tag come NUOVA VERSIONE su Zenodo, via API deposizioni. Sostituisce il webhook
-# GitHub->Zenodo (disattivato perche' dopo la migrazione a InvenioRDM falliva con
-# errore vuoto {"errors": ""}). Idempotente e non bloccante.
+# Archivia il SORGENTE di un tag come nuova versione su Zenodo (concept 5957132)
+# via API deposizioni. Due modi:
+#   - MANUALE: Actions > "Archive release to Zenodo" > Run workflow > indica il tag
+#   - automatico: alla pubblicazione di una Release stabile (non prerelease)
+# Idempotente e non bloccante. Richiede il secret ZENODO_TOKEN (scope
+# deposit:write + deposit:actions); se manca, lo script salta senza errore.
 #
-# Richiede il secret di repo ZENODO_TOKEN (scope deposit:write + deposit:actions).
-# Se il secret manca, lo script salta senza errore.
-#
-# Gira dal branch di DEFAULT (main) per l'evento `release`, qualunque sia il
-# branch da cui e' stato tagliato il tag.
+# Gira dal branch di DEFAULT (main). Il sorgente viene preso dal tag indicato;
+# .zenodo.json e lo script vengono presi da main (canonici), cosi' funziona
+# anche se quel tag non li contiene.
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag da archiviare su Zenodo (es. v.1.5.2)'
+        required: true
+        type: string
   release:
     types: [published]
 
 jobs:
   zenodo:
-    # solo release stabili (le prerelease non vanno archiviate)
-    if: ${{ !github.event.release.prerelease }}
+    # manuale: sempre; da release: solo stabili (non prerelease)
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0
 
-      - name: Build source archive of the released tag
+      - name: Prepare source archive + canonical metadata/script
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          # usa il .zenodo.json del tag se presente (metadati di quella versione);
-          # altrimenti resta quello del branch di default come fallback.
-          git show "refs/tags/${TAG}:.zenodo.json" > .zenodo.json 2>/dev/null || true
-          git archive --format=zip --prefix="ExtendedMatrix-${TAG}/" "refs/tags/${TAG}" \
-            -o "ExtendedMatrix-${TAG}.zip"
-          ls -la "ExtendedMatrix-${TAG}.zip" .zenodo.json
+          git archive --format=zip --prefix="ExtendedMatrix-${TAG}/" HEAD -o "ExtendedMatrix-${TAG}.zip"
+          git fetch origin main --depth=1 -q
+          git checkout origin/main -- .zenodo.json scripts/zenodo_publish.py
+          ls -la "ExtendedMatrix-${TAG}.zip" .zenodo.json scripts/zenodo_publish.py
 
       - name: Publish source to Zenodo
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
           ZENODO_CONCEPT: "5957132"
-          TAG: ${{ github.event.release.tag_name }}
-          SRC_ZIP: "ExtendedMatrix-${{ github.event.release.tag_name }}.zip"
+          SRC_ZIP: "ExtendedMatrix-${{ env.TAG }}.zip"
         run: python3 scripts/zenodo_publish.py

--- a/scripts/zenodo_publish.py
+++ b/scripts/zenodo_publish.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Publish a new version of this software/record to Zenodo via the deposit API.
+
+Used by CI to archive a STABLE release as a new version under the existing
+concept DOI, bypassing the GitHub->Zenodo webhook (which broke after the
+InvenioRDM migration and fails with an empty error: {"errors": ""}).
+
+Design / robustness:
+  * Idempotent: if the concept already has a version equal to TAG, exit 0.
+  * Non-blocking: standalone job, so if it fails the GitHub Release is
+    unaffected -- just archive that release manually.
+  * Uses the deposit API (which returns real error messages), not the webhook.
+  * If ZENODO_TOKEN is empty/missing it SKIPS (exit 0) instead of failing.
+
+Env:
+  ZENODO_TOKEN    Zenodo personal token (scopes: deposit:write, deposit:actions)
+  ZENODO_CONCEPT  concept record id (numeric), e.g. 5957132
+  TAG             the git tag / version string, e.g. v.1.5.2
+  SRC_ZIP         path to the source archive to upload
+Reads .zenodo.json (current dir) for the deposition metadata.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://zenodo.org/api"
+TOKEN = os.environ.get("ZENODO_TOKEN", "").strip()
+CONCEPT = os.environ.get("ZENODO_CONCEPT", "").strip()
+TAG = os.environ.get("TAG", "").strip()
+SRC_ZIP = os.environ.get("SRC_ZIP", "").strip()
+
+if not TOKEN:
+    print("ZENODO_TOKEN not set -> skipping Zenodo archival "
+          "(configure the repo secret to enable it).")
+    sys.exit(0)
+for _name, _val in (("ZENODO_CONCEPT", CONCEPT), ("TAG", TAG), ("SRC_ZIP", SRC_ZIP)):
+    if not _val:
+        print(f"ERROR: {_name} not set", file=sys.stderr)
+        sys.exit(1)
+
+
+def api(method, url, data=None, ctype=None):
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    if ctype:
+        headers["Content-Type"] = ctype
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read()
+            return resp.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        try:
+            return exc.code, json.loads(body or b"{}")
+        except Exception:
+            return exc.code, {"_raw": body.decode("utf-8", "replace")}
+
+
+def die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# 1. Resolve concept -> latest record; idempotency check.
+st, rec = api("GET", f"{API}/records/{CONCEPT}")
+if st != 200:
+    die(f"cannot resolve concept {CONCEPT}: HTTP {st} {rec}")
+latest_id = rec["id"]
+st, vers = api("GET", f"{API}/records/{latest_id}/versions?size=200&allversions=true")
+have = {v.get("metadata", {}).get("version")
+        for v in vers.get("hits", {}).get("hits", [])}
+if TAG in have:
+    print(f"Version {TAG} already archived on concept {CONCEPT} -> nothing to do.")
+    sys.exit(0)
+
+# 2. Metadata from .zenodo.json.
+with open(".zenodo.json", encoding="utf-8") as fh:
+    meta = json.load(fh)
+meta["version"] = TAG
+
+# 3. Create a new-version draft from the latest deposition.
+st, nv = api("POST", f"{API}/deposit/depositions/{latest_id}/actions/newversion")
+if st not in (200, 201):
+    die(f"newversion failed: HTTP {st} {nv}")
+draft_url = nv.get("links", {}).get("latest_draft")
+if not draft_url:
+    die(f"no latest_draft link returned: {nv}")
+st, draft = api("GET", draft_url)
+if st != 200:
+    die(f"get draft failed: HTTP {st} {draft}")
+draft_id = draft["id"]
+bucket = draft["links"]["bucket"]
+
+# 4. Set metadata.
+st, up = api("PUT", f"{API}/deposit/depositions/{draft_id}",
+             data=json.dumps({"metadata": meta}).encode("utf-8"),
+             ctype="application/json")
+if st != 200:
+    die(f"metadata update failed: HTTP {st} {up}")
+
+# 5. Drop inherited files (the previous version's archive).
+for f in draft.get("files", []):
+    api("DELETE", f"{API}/deposit/depositions/{draft_id}/files/{f.get('id')}")
+
+# 6. Upload the new source archive to the draft's bucket.
+fname = os.path.basename(SRC_ZIP)
+with open(SRC_ZIP, "rb") as fh:
+    blob = fh.read()
+st, _ = api("PUT", f"{bucket}/{urllib.parse.quote(fname)}",
+            data=blob, ctype="application/octet-stream")
+if st not in (200, 201):
+    die(f"file upload failed for {fname}: HTTP {st}")
+print(f"Uploaded {fname} ({len(blob)} bytes)")
+
+# 7. Publish.
+st, pub = api("POST", f"{API}/deposit/depositions/{draft_id}/actions/publish")
+if st not in (200, 202):
+    die(f"publish failed: HTTP {st} {pub}")
+print("Published new version:", pub.get("doi") or pub.get("doi_url") or draft_id)


### PR DESCRIPTION
Aggiunge il sync automatico verso Zenodo per le **release stabili**, sostituendo il webhook GitHub->Zenodo (disattivato: dopo la migrazione a InvenioRDM falliva con errore vuoto).

- Trigger: \`release: published\`, **solo non-prerelease**.
- Archivia il **sorgente** del tag come nuova versione sotto il concept \`5957132\` via API deposizioni.
- **Idempotente** (salta se la versione esiste gia) e **non bloccante** (se fallisce, la Release resta valida).
- Richiede il secret repo \`ZENODO_TOKEN\` (scope deposit:write + deposit:actions); se manca, salta senza errore.

File: \`.github/workflows/zenodo.yml\` + \`scripts/zenodo_publish.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)